### PR TITLE
Update team_level_tips.csv

### DIFF
--- a/content/data/team_level_tips.csv
+++ b/content/data/team_level_tips.csv
@@ -1,20 +1,20 @@
 teamLevel,requirement,action,totalStarters,totalAllStars,totalAllWorlds
-1 → 2,Rank 1 Level 2 x1,Level up 1 Starter to Rank 1 Level 2,Rank 1 Level 2 x1,,
-2 → 3,Rank 1 Level 2 x3,Level up 2 new Starters to Rank 1 Level 2,Rank 1 Level 2 x3,,
-3 → 4,Rank 1 Level 7 x3,Level up all 3 Starters from Rank 1 Level 2 to Rank 1 Level 7,Rank 1 Level 7 x3,,
-4 → 5,Rank 1 Level 10 x2,Level up 2 Starters from Rank 1 Level 7 to Rank 1 Level 10,"Rank 1 Level 10 x2, Rank 1 Level 7 x1",,
-5 → 6,Rank 2 x2,Rank up 2 Rank 1 Level 10 Starters to Rank 2,"Rank 2 x2, Rank 1 Level 7 x1",,
-6 → 7,Rank 2 x4,Rank up a new Starter and the remaining Rank 1 Level 7 Starter to Rank 2,Rank 2 x4,,
-7 → 8,Rank 1 Level 7 x10,Level up 6 new Starters to Rank 1 Level 7,"Rank 2 x4, Rank 1 Level 7 x6",,
-8 → 9,Rank 1 Level 7 x12,Level up 2 new Starters to Rank 1 Level 7,"Rank 2 x4, Rank 1 Level 7 x8",,
-9 → 10,Rank 1 Level 10 x9,Level up 5 Rank 1 Level 7 Starters to Rank 1 Level 10,"Rank 2 x4, Rank 1 Level 10 x5, Rank 1 Level 7 x3",,
-10 → 11,Rank 3 x2,Rank up 2 Rank 2 Starters to Rank 3,"Rank 3 x2, Rank 2 x2, Rank 1 Level 10 x5, Rank 1 Level 7 x3",,
-11 → 12,Rank 3 x4,Rank up 2 more Rank 2 Starters to Rank 3,"Rank 3 x4, Rank 1 Level 10 x5, Rank 1 Level 7 x3",,
-12 → 13,Rank 3 x7,Rank up 3 Rank 1 Level 10 Starters to Rank 3,"Rank 3 x7, Rank 1 Level 10 x2, Rank 1 Level 7 x3",,
-13 → 14,Rank 3 x10,Rank up 3 Rank 2 All-Star to Rank 3,"Rank 3 x7, Rank 1 Level 10 x2, Rank 1 Level 7 x3",Rank 3 x3,
-14 → 15,Rank 4 x2,Rank up 2 Rank 3 Starters to Rank 4,"Rank 4 x2, Rank 3 x5, Rank 1 Level 10 x2, Rank 1 Level 7 x3",Rank 3 x3,
-15 → 16,Rank 4 x4,Rank up 2 more Rank 3 Starters to Rank 4,"Rank 4 x4, Rank 3 x3, Rank 1 Level 10 x2, Rank 1 Level 7 x3",Rank 3 x3,
-16 → 17,Rank 4 x10,"Rank up 2 Rank 3 Starters, 3 Rank 3 All-Star and 1 All-World to Rank 4","Rank 4 x6, Rank 3 x1, Rank 1 Level 10 x2, Rank 1 Level 7 x3",Rank 4 x3,Rank 4 x1
-17 → 18,Rank 5 x2,Rank up 2 Rank 4 All-Star to Rank 5,"Rank 4 x6, Rank 3 x1, Rank 1 Level 10 x2, Rank 1 Level 7 x3","Rank 5 x2, Rank 4 x1",Rank 4 x1
-18 → 19,Rank 5 x4,Rank up the remaining Rank 4 All-Star and the Rank 4 All-World to Rank 5,"Rank 4 x6, Rank 3 x1, Rank 1 Level 10 x2, Rank 1 Level 7 x3",Rank 5 x3,Rank 5 x1
-19 → 20,Rank 6 x1,Rank up the Rank 5 All-World to Rank 6,"Rank 4 x6, Rank 3 x1, Rank 1 Level 10 x2, Rank 1 Level 7 x3",Rank 5 x3,Rank 6 x1
+1 → 2,Level 2 x1,Level up 1 Starter to Rank 1 Level 2 (R1L2),R1L2 x1,,
+2 → 3,Level 2 x3,Level up 2 new Starters to R1L2,R1L2 x3,,
+3 → 4,Level 7 x3,Level up all 3 Starters from R1L2 to R1L7,R1L7 x3,,
+4 → 5,Level 10 x2,Level up 2 Starters from R1L7 to R1L10,"R1L10 x2, R1L7 x1",,
+5 → 6,Rank 2 x2,Rank up 2 R1L10 Starters to Rank 2 (R2),"R2 x2, R1L7 x1",,
+6 → 7,Rank 2 x4,Level up a new Starter and the remaining R1L7 Starter to R1L10 then Rank up to R2,R2L1 x4,,
+7 → 8,Level 7 x10,Level up 3 new Starters to R1L7 and 3 All-Stars to R2L7,"R2L1 x4, R1L7 x3",R2L7 x3,
+8 → 9,Level 7 x12,Level up 2 new Starters to R1L7,"R2L1 x4, R1L7 x5",R2L7 x3,
+9 → 10,Level 10 x9,Level up 3 R1L7 Starters to R1L10 and 2 All-Stars to R2L7,"R2L1 x4, R1L10 x3, R1L7 x2","R2L10 x2, R2L7 x1",
+10 → 11,Rank 3 x2,Rank up 2 R2 Starters to Rank 3 (R3),"R3L1 x2, R2L1 x2, R1L10 x3, R1L7 x2","R2L10 x2, R2L7 x1",
+11 → 12,Rank 3 x4,Rank up 2 more R2 Starters to R3,"R3L1 x4, R1L10 x3, R1L7 x2","R2L10 x2, R2L7 x1",
+12 → 13,Rank 3 x7,Rank up 3 R1L10 Starters to Rank 3,"R3L1 x7, R1L7 x2","R2L10 x2, R2L7 x1",
+13 → 14,Rank 3 x10,Level up remaining R2L7 All-Star to R2L10 and Rank up all 3 R2L10 All-Stars to R3,"R3L1 x7, R1L7 x2",R3L1 x3,
+14 → 15,Rank 4 x2,Rank up 2 R3 Starters to Rank 4 (R4),"R4L1 x2, R3L1 x5, R1L7 x2",R3L1 x3,
+15 → 16,Rank 4 x4,Rank up 2 more R3 Starters to R4,"R4L1 x4, R3L1 x3, R1L7 x2",R3L1 x3,
+16 → 17,Rank 4 x10,"Rank up 2 R3 Starters, 3 R3 All-Star and 1 All-World to R4","R4L1 x6, R3L1 x1, R1L7 x2",R4L1 x3,R4L1 x1
+17 → 18,Rank 5 x2,Rank up 2 R4 All-Star to Rank 5 (R5),"R4L1 x6, R3L1 x1, R1L7 x2","R5L1 x2, R4L1 x1",R4L1 x1
+18 → 19,Rank 5 x4,Rank up the remaining R4 All-Star and the R4 All-World to R5,"R4L1 x6, R3L1 x1, R1L7 x2",R5L1 x3,R5L1 x1
+19 → 20,Rank 6 x1,Rank up the R5 All-World to Rank 6 (R6),"R4L1 x6, R3L1 x1, R1L7 x2",R5L1 x3,R6L1 x1


### PR DESCRIPTION
Tweaked the Level up requirements to level All-Stars earlier to avoid leveling up more Starters than is necessary and added abbreviations for Rank and Level (R2L7 = Rank 2 Level 7)