### PR TITLE
Added a note for abbreviations at the top of the team level tips table and made wording in team level tips more consistent.

### DIFF
--- a/content/data/team_level_tips.csv
+++ b/content/data/team_level_tips.csv
@@ -1,20 +1,20 @@
 teamLevel,requirement,action,totalStarters,totalAllStars,totalAllWorlds
-1 → 2,Level 2 x1,Level up 1 Starter to Rank 1 Level 2 (R1L2),R1L2 x1,,
+1 → 2,Level 2 x1,Level up 1 Starter to R1L2,R1L2 x1,,
 2 → 3,Level 2 x3,Level up 2 new Starters to R1L2,R1L2 x3,,
 3 → 4,Level 7 x3,Level up all 3 Starters from R1L2 to R1L7,R1L7 x3,,
 4 → 5,Level 10 x2,Level up 2 Starters from R1L7 to R1L10,"R1L10 x2, R1L7 x1",,
-5 → 6,Rank 2 x2,Rank up 2 R1L10 Starters to Rank 2 (R2),"R2L1 x2, R1L7 x1",,
-6 → 7,Rank 2 x4,Level up a new Starter and the remaining R1L7 Starter to R1L10 then Rank up to R2,R2L1 x4,,
+5 → 6,Rank 2 x2,Rank up both R1L10 Starters to R2L1,"R2L1 x2, R1L7 x1",,
+6 → 7,Rank 2 x4,Level up a new Starter and the remaining R1L7 Starter to R1L10 then rank them up to R2L1,R2L1 x4,,
 7 → 8,Level 7 x10,Level up 3 new Starters to R1L7 and 3 All-Stars to R2L7,"R2L1 x4, R1L7 x3",R2L7 x3,
 8 → 9,Level 7 x12,Level up 2 new Starters to R1L7,"R2L1 x4, R1L7 x5",R2L7 x3,
 9 → 10,Level 10 x9,Level up 3 R1L7 Starters to R1L10 and 2 All-Stars to R2L7,"R2L1 x4, R1L10 x3, R1L7 x2","R2L10 x2, R2L7 x1",
-10 → 11,Rank 3 x2,Rank up 2 R2 Starters to Rank 3 (R3),"R3L1 x2, R2L1 x2, R1L10 x3, R1L7 x2","R2L10 x2, R2L7 x1",
-11 → 12,Rank 3 x4,Rank up 2 more R2 Starters to R3,"R3L1 x4, R1L10 x3, R1L7 x2","R2L10 x2, R2L7 x1",
-12 → 13,Rank 3 x7,Rank up 3 R1L10 Starters to Rank 3,"R3L1 x7, R1L7 x2","R2L10 x2, R2L7 x1",
-13 → 14,Rank 3 x10,Level up remaining R2L7 All-Star to R2L10 and Rank up all 3 R2L10 All-Stars to R3,"R3L1 x7, R1L7 x2",R3L1 x3,
-14 → 15,Rank 4 x2,Rank up 2 R3 Starters to Rank 4 (R4),"R4L1 x2, R3L1 x5, R1L7 x2",R3L1 x3,
-15 → 16,Rank 4 x4,Rank up 2 more R3 Starters to R4,"R4L1 x4, R3L1 x3, R1L7 x2",R3L1 x3,
-16 → 17,Rank 4 x10,"Rank up 2 R3 Starters, 3 R3 All-Star and 1 All-World to R4","R4L1 x6, R3L1 x1, R1L7 x2",R4L1 x3,R4L1 x1
-17 → 18,Rank 5 x2,Rank up 2 R4 All-Star to Rank 5 (R5),"R4L1 x6, R3L1 x1, R1L7 x2","R5L1 x2, R4L1 x1",R4L1 x1
-18 → 19,Rank 5 x4,Rank up the remaining R4 All-Star and the R4 All-World to R5,"R4L1 x6, R3L1 x1, R1L7 x2",R5L1 x3,R5L1 x1
-19 → 20,Rank 6 x1,Rank up the R5 All-World to Rank 6 (R6),"R4L1 x6, R3L1 x1, R1L7 x2",R5L1 x3,R6L1 x1
+10 → 11,Rank 3 x2,Rank up 2 R2L1 Starters to R3L1,"R3L1 x2, R2L1 x2, R1L10 x3, R1L7 x2","R2L10 x2, R2L7 x1",
+11 → 12,Rank 3 x4,Rank up the remaining 2 R2L1 Starters to R3L1,"R3L1 x4, R1L10 x3, R1L7 x2","R2L10 x2, R2L7 x1",
+12 → 13,Rank 3 x7,Rank up all 3 R1L10 Starters to R3L1,"R3L1 x7, R1L7 x2","R2L10 x2, R2L7 x1",
+13 → 14,Rank 3 x10,Level up the remaining R2L7 All-Star to R2L10 and rank up all 3 R2L10 All-Stars to R3L1,"R3L1 x7, R1L7 x2",R3L1 x3,
+14 → 15,Rank 4 x2,Rank up 2 R3L1 Starters to R4L1,"R4L1 x2, R3L1 x5, R1L7 x2",R3L1 x3,
+15 → 16,Rank 4 x4,Rank up 2 more R3L1 Starters to R4L1,"R4L1 x4, R3L1 x3, R1L7 x2",R3L1 x3,
+16 → 17,Rank 4 x10,"Rank up 2 R3L1 Starters, all 3 R3L1 All-Star and 1 All-World to R4L1","R4L1 x6, R3L1 x1, R1L7 x2",R4L1 x3,R4L1 x1
+17 → 18,Rank 5 x2,Rank up 2 R4L1 All-Star to R5L1,"R4L1 x6, R3L1 x1, R1L7 x2","R5L1 x2, R4L1 x1",R4L1 x1
+18 → 19,Rank 5 x4,Rank up the remaining R4L1 All-Star and the R4L1 All-World to R5L1,"R4L1 x6, R3L1 x1, R1L7 x2",R5L1 x3,R5L1 x1
+19 → 20,Rank 6 x1,Rank up the R5L1 All-World to R6L1,"R4L1 x6, R3L1 x1, R1L7 x2",R5L1 x3,R6L1 x1

--- a/src/pages/tips.js
+++ b/src/pages/tips.js
@@ -15,6 +15,11 @@ export default function TipsPage({ data }) {
       <Page useSplashScreenAnimation>
         <Animation type="fadeUp">
           <Section anchor="level-up-team-level-fast" heading="Level Up Team Level Fast">
+            <h5>
+              R: Rank, L: Level.
+              <br />
+              Example: R1L7 → Rank 1 Level 7
+            </h5>
             <TeamLevelTipsTable defaultPageSize={defaultPageSize} data={data.allTeamLevelTipsCsv.nodes}/>
           </Section>
         </Animation>


### PR DESCRIPTION
Screenshot:

![Screenshot 2023-05-03 at 13 15 54](https://user-images.githubusercontent.com/6475138/236007522-1a3033e2-cd4b-4102-9db3-d9f6236e7d76.png)
